### PR TITLE
ci: add NuGet package version to job summary

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -271,8 +271,8 @@ jobs:
       - name: Add NuGet Summary
         shell: pwsh
         run: |
-          echo "### NuGet Package Summary" >> $env:GITHUB_STEP_SUMMARY
-          echo "Package version: ``${{ steps.nbgv.outputs.SemVer2 }}``" >> $env:GITHUB_STEP_SUMMARY
+          echo '### NuGet Package Summary' >> $env:GITHUB_STEP_SUMMARY
+          echo 'Package version: `${{ steps.nbgv.outputs.SemVer2 }}`' >> $env:GITHUB_STEP_SUMMARY
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -268,6 +268,12 @@ jobs:
           .\nuget.exe pack uno.icu-win/uno.icu-win.nuspec -version ${{ steps.nbgv.outputs.SemVer2 }}
           popd
 
+      - name: Add NuGet Summary
+        shell: pwsh
+        run: |
+          echo "### NuGet Package Summary" >> $env:GITHUB_STEP_SUMMARY
+          echo "Package version: ``${{ steps.nbgv.outputs.SemVer2 }}``" >> $env:GITHUB_STEP_SUMMARY
+
       - uses: actions/upload-artifact@v4
         with:
           name: nuget


### PR DESCRIPTION
Adds the NuGet package version (from nbgv) to the GitHub Actions job summary in the `package` job, making it easy to see the built version directly from the Actions run page.

Note: No related issue (Internal maintenance).