### PR TITLE
feat(uno.icu-ios): add a Mac Catalyst slice

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -186,7 +186,7 @@ jobs:
           path: ./libicu_osx_universal/*
 
   package:
-    needs: [build_unoicu, build_icudt, build_libicu_osx_universal, build_libicu_iossim_universal, build_libicu_ios, build_libicu_windows]
+    needs: [build_unoicu, build_icudt, build_libicu_osx_universal, build_libicu_iossim_universal, build_libicu_ios, build_libicu_maccatalyst_universal, build_libicu_windows]
     runs-on: windows-latest
 
     steps:
@@ -198,7 +198,7 @@ jobs:
         uses: actions/upload-artifact/merge@v4
         with:
           name: merged-artifacts
-          pattern: '{libicu_osx_universal,libicu_iossim_universal,libicu_ios,libicu-windows-*,unoicu-*,icudt.dat}'
+          pattern: '{libicu_osx_universal,libicu_iossim_universal,libicu_ios,libicu_maccatalyst_universal,libicu-windows-*,unoicu-*,icudt.dat}'
           separate-directories: true
 
       - name: Download merged artifacts
@@ -220,6 +220,8 @@ jobs:
           mv merged-artifacts/libicu_iossim_universal/{libicuuc,libicudata}.a ./nuget/uno.icu-ios/iossim
           mkdir nuget/uno.icu-ios/ios
           mv merged-artifacts/libicu_ios/{libicuuc,libicudata}.a ./nuget/uno.icu-ios/ios
+          mkdir nuget/uno.icu-ios/maccatalyst
+          mv merged-artifacts/libicu_maccatalyst_universal/{libicuuc,libicudata}.a ./nuget/uno.icu-ios/maccatalyst
 
           mkdir -p nuget/uno.icu-win/libicu/x64
           mv merged-artifacts/libicu-windows-x64/* ./nuget/uno.icu-win/libicu/x64
@@ -493,3 +495,72 @@ jobs:
         with:
           name: libicu_iossim_universal
           path: ./libicu_iossim_universal/*
+
+  build_libicu_maccatalyst:
+    strategy:
+      matrix:
+        arch: [ 'arm64', 'x86_64' ]
+    runs-on: 'macos-15' # arm64
+    needs: build_libicu_osx
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Download Artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: libicu-osx-arm64-build
+          path: ./osx-arm64-build
+
+      - name: Build ICU
+        run: |
+          # Mac Catalyst (macabi) has no dedicated SDK directory: it compiles against the macOS SDK
+          # with an -ios<version>-macabi target triple. 15.0 matches Uno's own Mac Catalyst minimum
+          # (SupportedOSPlatformVersion in src/Uno.CrossTargetting.targets) and the
+          # net10.0-maccatalyst workload's assumed default.
+          curl -L -o icu.zip ${ICU_SOURCE_ZIP_URL}
+          mkdir icu
+          unzip -d icu icu.zip
+          export ICU_DATA_FILTER_FILE="$PWD/src/cldr_data/filters.json"
+          CROSS_BUILD_DIR="$(pwd)/osx-arm64-build"
+          chmod +x $CROSS_BUILD_DIR/source/bin/* # the exec bit is lost during github actions uploading and downloading
+          pushd icu/$(ls icu)/icu4c/source
+          ./configure --enable-static --disable-shared --with-data-packaging=static --disable-tools --disable-extras --disable-tests --disable-samples --disable-dyload --host=arm-apple-darwin --build=${{ matrix.arch }}-apple --with-cross-build="$CROSS_BUILD_DIR"/source CFLAGS="-target ${{ matrix.arch }}-apple-ios15.0-macabi -isysroot $(xcode-select -print-path)/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk" CXXFLAGS="-target ${{ matrix.arch }}-apple-ios15.0-macabi -isysroot $(xcode-select -print-path)/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk -c -stdlib=libc++ --std=c++17" LDFLAGS="-target ${{ matrix.arch }}-apple-ios15.0-macabi -stdlib=libc++ -lstdc++"
+          make -j $(sysctl -n hw.physicalcpu)
+          popd
+          mkdir lib
+          cp icu/$(ls icu)/icu4c/source/lib/libicuuc.a icu/$(ls icu)/icu4c/source/lib/libicudata.a lib
+
+      - name: Upload binaries
+        uses: actions/upload-artifact@v4
+        with:
+          name: libicu-maccatalyst-${{ matrix.arch }}
+          path: ./lib
+
+  build_libicu_maccatalyst_universal:
+    needs: [build_libicu_maccatalyst]
+    runs-on: 'macos-15'
+    steps:
+      - name: Merge libicu binaries
+        uses: actions/upload-artifact/merge@v4
+        with:
+          name: libicu-maccatalyst-merged
+          pattern: 'libicu-maccatalyst-*'
+          separate-directories: true
+
+      - name: Download merged libicu binaries
+        uses: actions/download-artifact@v4
+        with:
+          name: libicu-maccatalyst-merged
+          path: ./libicu-maccatalyst-merged
+
+      - name: Create universal libicu binaries
+        run: |
+          mkdir libicu_maccatalyst_universal
+          lipo -create libicu-maccatalyst-merged/**/libicuuc.a -output libicu_maccatalyst_universal/libicuuc.a
+          lipo -create libicu-maccatalyst-merged/**/libicudata.a -output libicu_maccatalyst_universal/libicudata.a
+
+      - name: Upload universal libicu binaries
+        uses: actions/upload-artifact@v4
+        with:
+          name: libicu_maccatalyst_universal
+          path: ./libicu_maccatalyst_universal/*

--- a/nuget/uno.icu-ios/buildTransitive/Uno.icu-ios.targets
+++ b/nuget/uno.icu-ios/buildTransitive/Uno.icu-ios.targets
@@ -2,19 +2,30 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
     <ItemGroup Condition="'$(IsUnoHead)' == 'True'">
-        <NativeReference Condition="!$(RuntimeIdentifier.Contains('iossimulator'))" Include="$(MSBuildThisFileDirectory)ios/libicuuc.a">
+        <!-- iOS device -->
+        <NativeReference Condition="!$(RuntimeIdentifier.Contains('iossimulator')) and !$(RuntimeIdentifier.Contains('maccatalyst'))" Include="$(MSBuildThisFileDirectory)ios/libicuuc.a">
             <Kind>Static</Kind>
             <ForceLoad>True</ForceLoad>
         </NativeReference>
-        <NativeReference Condition="!$(RuntimeIdentifier.Contains('iossimulator'))" Include="$(MSBuildThisFileDirectory)ios/libicudata.a">
+        <NativeReference Condition="!$(RuntimeIdentifier.Contains('iossimulator')) and !$(RuntimeIdentifier.Contains('maccatalyst'))" Include="$(MSBuildThisFileDirectory)ios/libicudata.a">
             <Kind>Static</Kind>
             <ForceLoad>True</ForceLoad>
         </NativeReference>
+        <!-- iOS simulator -->
         <NativeReference Condition="$(RuntimeIdentifier.Contains('iossimulator'))" Include="$(MSBuildThisFileDirectory)iossim/libicuuc.a">
             <Kind>Static</Kind>
             <ForceLoad>True</ForceLoad>
         </NativeReference>
         <NativeReference Condition="$(RuntimeIdentifier.Contains('iossimulator'))" Include="$(MSBuildThisFileDirectory)iossim/libicudata.a">
+            <Kind>Static</Kind>
+            <ForceLoad>True</ForceLoad>
+        </NativeReference>
+        <!-- Mac Catalyst (macabi) -->
+        <NativeReference Condition="$(RuntimeIdentifier.Contains('maccatalyst'))" Include="$(MSBuildThisFileDirectory)maccatalyst/libicuuc.a">
+            <Kind>Static</Kind>
+            <ForceLoad>True</ForceLoad>
+        </NativeReference>
+        <NativeReference Condition="$(RuntimeIdentifier.Contains('maccatalyst'))" Include="$(MSBuildThisFileDirectory)maccatalyst/libicudata.a">
             <Kind>Static</Kind>
             <ForceLoad>True</ForceLoad>
         </NativeReference>

--- a/nuget/uno.icu-ios/uno.icu-ios.nuspec
+++ b/nuget/uno.icu-ios/uno.icu-ios.nuspec
@@ -19,5 +19,7 @@
         <file src="ios\libicudata.a" target="buildTransitive\ios" />
         <file src="iossim\libicuuc.a" target="buildTransitive\iossim" />
         <file src="iossim\libicudata.a" target="buildTransitive\iossim" />
+        <file src="maccatalyst\libicuuc.a" target="buildTransitive\maccatalyst" />
+        <file src="maccatalyst\libicudata.a" target="buildTransitive\maccatalyst" />
     </files>
 </package>


### PR DESCRIPTION
## Problem

`Uno.icu-ios` is the ICU dependency `Uno.WinUI.Runtime.Skia.AppleUIKit` declares for **all three** UIKit TFMs — `ios`, `tvos`, and `maccatalyst` — but the package ships only iOS device and simulator slices. A Mac Catalyst head therefore cannot link:

```
ld: building for 'macCatalyst', but linking in object file
    (.../uno.icu-ios/77.1.2/buildTransitive/ios/libicuuc.a[2](appendable.ao)) built for 'iOS'
```

Dropping the reference is not a workaround: the Skia text stack needs versioned ICU 77 symbols (`_ubidi_open_77`, `_u_errorName_77`, ...) that Apple's system ICU does not export, so the link then fails on undefined symbols instead. Today no Uno Skia app can produce a Mac Catalyst build at all (unoplatform/uno#23733).

## Fix

Add a Mac Catalyst slice to `Uno.icu-ios`, mirroring the existing iOS lanes:

- **`build_libicu_maccatalyst`** — same cross-build recipe as `build_libicu_ios` (ICU 77.1, `filters.json` data filter, static, `--with-cross-build` from the osx-arm64 host build), per arch (`arm64`, `x86_64`). Catalyst has no dedicated SDK directory: it compiles against the **macOS SDK** with a `-target <arch>-apple-ios15.0-macabi` triple; 15.0 matches Uno's own Mac Catalyst minimum (`SupportedOSPlatformVersion` in `src/Uno.CrossTargetting.targets`) and the `net10.0-maccatalyst` workload's assumed default.
- **`build_libicu_maccatalyst_universal`** — `lipo` merge, same as the iossim lane.
- **package job** — moves the universal libs to `nuget/uno.icu-ios/maccatalyst/`; nuspec ships them.
- **`Uno.icu-ios.targets`** — the RID condition becomes three-way: `maccatalyst` RIDs get the new slice; `iossimulator` and device behavior are unchanged.

## Validation

The technique is proven end to end downstream (this is not theoretical):

- ICU 77.1 built with exactly this configure/`-target` recipe produces objects with `LC_BUILD_VERSION platform 6` (MACCATALYST) and the expected versioned symbols (`T _u_errorName_77`) — verified with `otool`/`nm`.
- A real Uno single-project app (`net10.0-maccatalyst`, Uno.Sdk 6.5.x, SkiaRenderer) that previously failed with the errors above **builds and native-links with 0 errors** on a clean `macos-26` runner when these catalyst-built `libicuuc.a`/`libicudata.a` replace the iOS slice — the only change.
- YAML/XML in this PR validated; the workflow edits mirror the existing iossim/ios lanes structurally.

One note for reviewers: the iOS lanes run on `macos-15` with `-mios-version-min=13.4`; the new lane reuses `macos-15`. My downstream validation compiled the libraries with Xcode 16.4 — Catalyst target support in clang is long-settled, so runner Xcode drift should not affect this lane.

Happy to adjust the min version, naming, or split anything out.

