### PR TITLE
ci: build unoicu.a for emscripten 5.0.6 (.NET 11 preview 6)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        EMSCRIPTEN_VERSION: [ '3.1.56' ]
+        # Build one set of archives per emscripten version consumed by a supported .NET runtime.
+        # The Uno.Wasm.Bootstrap native-file selector picks the archive matching the consumer's
+        # emscripten version (see nuget/uno.icu-wasm/buildTransitive/Uno.icu-wasm.targets).
+        #   3.1.56 -> .NET 9 / .NET 10
+        #   5.0.6  -> .NET 11 (preview 6+)
+        EMSCRIPTEN_VERSION: [ '3.1.56', '5.0.6' ]
         multithreaded: [true, false]
         simd: [true, false]
     steps:


### PR DESCRIPTION
## What
Add emscripten **5.0.6** to the `unoicu.a` build matrix, alongside the existing **3.1.56**.

## Why
.NET 11 preview 6 bumped the WebAssembly runtime's emscripten toolchain from 3.1.56 (net9/net10) to 5.0.6. Uno.Wasm.Bootstrap's `BitcodeFilesSelector` picks the `unoicu.a` archive matching the consumer's emscripten version from the `unoicu.a/<emver>/<features>/` layout. Since the package only shipped 3.1.56 archives, a .NET 11 preview 6 head has no matching archive and the native link fails.

## Change
- `.github/workflows/main.yml`: `EMSCRIPTEN_VERSION: [ '3.1.56', '5.0.6' ]`

No `Dockerfile` or targets changes needed — the Dockerfile is parameterized by `EMSCRIPTEN_VERSION` (pulls `emscripten/emsdk:5.0.6`) and its build steps work unchanged; packaging and the `**/unoicu.a` glob pick up the new version folder automatically.

## Verification
Using the emscripten 5.0.6 toolchain from the .NET 11 preview 6 `wasm-tools` workload (no Docker):
- Built `unoicu.a` for 5.0.6 (`st` and `st,simd`) with the exact Dockerfile steps — clean.
- Ran Uno's real `BitcodeFilesSelector`: selects `5.0.6` on preview 6, still `3.1.56` on net10 (no regression).
- Full `dotnet publish` of a .NET 11 preview 6 Blazor WASM repro: fails with only 3.1.56 shipped (`Could not find NativeFileReference .../5.0.6/...`), succeeds once the 5.0.6 archive is present; `uno_u_errorName` is defined in the final `dotnet.native.wasm` (archive statically linked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
