### PR TITLE
Version bump after 77.3 release branch

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "77.3-dev.{height}",
+  "version": "77.4-dev.{height}",
   "nuGetPackageVersion": {
     "semVer": 2.0
   },


### PR DESCRIPTION
## What
Add emscripten **5.0.6** to the `unoicu.a` build matrix, alongside the existing **3.1.56**.

## Why
.NET 11 preview 6 bumped the WebAssembly runtime's emscripten toolchain from 3.1.56 (net9/net10) to 5.0.6. Uno.Wasm.Bootstrap's `BitcodeFilesSelector` picks the `unoicu.a` archive matching the consumer's emscripten version from the `unoicu.a/<emver>/<features>/` layout. Since the package only shipped 3.1.56 archives, a .NET 11 preview 6 head has no matching archive and the native link fails.

## Change
- `.github/workflows/main.yml`: `EMSCRIPTEN_VERSION: [ '3.1.56', '5.0.6' ]`

No `Dockerfile` or targets changes needed — the Dockerfile is parameterized by `EMSCRIPTEN_VERSION` (pulls `emscripten/emsdk:5.0.6`) and its build steps work unchanged; packaging and the `**/unoicu.a` glob pick up the new version folder automatically.

## Verification
Using the emscripten 5.0.6 toolchain from the .NET 11 preview 6 `wasm-tools` workload (no Docker):
- Built `unoicu.a` for 5.0.6 (`st` and `st,simd`) with the exact Dockerfile steps — clean.
- Ran Uno's real `BitcodeFilesSelector`: selects `5.0.6` on preview 6, still `3.1.56` on net10 (no regression).
- Full `dotnet publish` of a .NET 11 preview 6 Blazor WASM repro: fails with only 3.1.56 shipped (`Could not find NativeFileReference .../5.0.6/...`), succeeds once the 5.0.6 archive is present; `uno_u_errorName` is defined in the final `dotnet.native.wasm` (archive statically linked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

This is an automated version bump of the  **main** branch after the creation of the release branch release/stable/77.3, based on #27