### PR TITLE
ci: update .NET SDK version to 10.0.x in tag-release workflow

### DIFF
--- a/.github/workflows/actions/tag-release/action.yml
+++ b/.github/workflows/actions/tag-release/action.yml
@@ -8,9 +8,9 @@ runs:
     uses: actions/checkout@v2
 
   - name: Setup .NET SDK
-    uses: actions/setup-dotnet@v1
+    uses: actions/setup-dotnet@v4
     with:
-      dotnet-version: '9.0.300'
+      dotnet-version: '10.0.x'
 
   - uses: dotnet/nbgv@f088059084cb5d872e9d1a994433ca6440c2bf72 # v0.4.2
     name: NBGV


### PR DESCRIPTION
This pull request updates the .NET SDK setup step in the GitHub Actions workflow to use newer versions. This ensures the workflow uses the latest features and improvements from the .NET ecosystem.

Dependency and version updates:

* [`.github/workflows/actions/tag-release/action.yml`](diffhunk://#diff-468f1560e621ad1b1ed6efc0cd80180c2ce910bd3479151c10b926ee988f8658L11-R13): Updated the `actions/setup-dotnet` action from `v1` to `v4` and changed the `dotnet-version` from `9.0.300` to `10.0.x` to use the latest .NET SDK.