### PR TITLE
perf(wasm): drop CLDR locales_tree from ICU data

### DIFF
--- a/src/cldr_data/filters.json
+++ b/src/cldr_data/filters.json
@@ -11,7 +11,6 @@
         "brkitr_tree": "include",
         "uemoji": "include",
         "cnvalias": "include",
-        "locales_tree": "include",
         "ulayout": "include"
     },
     "localeFilter": {


### PR DESCRIPTION
GitHub Issue (If applicable): #32

## PR Type

- Build or CI related changes

## What is the current behavior?

`src/cldr_data/filters.json` includes `locales_tree` in its `featureFilters`, so the generated `icudt.dat` carries the full CLDR locale tree for the 62 whitelisted locales.

`Uno.icu.Common.targets` embeds that file as an `EmbeddedResource` into every Uno head. On WebAssembly it therefore lands inside the app's own assembly, on the startup critical path — the runtime cannot invoke `Main()` until the app assembly has downloaded.

Measured on a blank Uno Skia WASM app (Uno.Sdk 6.6.42, Release publish):

```
$ monodis --presources bin/Release/net10.0-browserwasm/UnoSkiaWasm.dll
386: UnoSkiaWasm.icudt.dat (size 5505504)     ← 91.7% of the 6,002,176-byte app DLL
```

That is 2 499 KB brotli on the wire, versus 48 KB for an equivalent Avalonia Browser app assembly.

## What is the new behavior?

`locales_tree` is removed from `featureFilters`. `localeFilter` is retained, because it also constrains which locales `brkitr_tree` emits.

Uno's ICU surface is narrow — `UnicodeText.ICU` in `unoplatform/uno` declares only `ubidi_*`, `ubrk_*`, `uscript_getScript`, `udata_setCommonData` and the `u_getVersion`/`u_errorName` helpers, i.e. bidirectional text, break iteration and script properties. None of those read the CLDR locales tree, which supplies date/number/currency formatting and locale display names.

Parsing the current package's table of contents (509 items):

| Contents | Size | Disposition |
|---|---:|---|
| `brkitr/` — break rules + CJK/SEA word dictionaries | 3.63 MB | kept, needed by `ubrk_*` |
| Top-level locale `.res` — 469 CLDR bundles | 1.52 MB | **removed by this PR** |
| `root.res` / `pool.res` | 0.09 MB | kept |

Expected result: ~1.5 MB (29%) smaller `icudt.dat`, roughly 0.7 MB less brotli on the WASM startup critical path, with no change to break iteration or bidi.

The `brkitr` dictionaries are the largest single block (`cjdict.dict` alone is 1.96 MB) but are what makes word and line breaking correct in Chinese, Japanese, Thai, Lao, Khmer and Burmese, so they are deliberately kept.

## Validation ⚠️

**This change has not been built or functionally validated locally** — building the data package needs Docker and a full ICU4C build, which were not available on the machine used to prepare it. The reasoning is derived from parsing the shipped `icudt.dat` directly and from the ICU API surface Uno actually calls.

Before merging, please confirm:

1. CI builds `src/cldr_data/Dockerfile` successfully and the resulting `icudt.dat` is ~3.7 MB.
2. `brkitr` resolution still works with the locales tree absent — i.e. `ubrk_open` still opens for a non-root locale. This is the one real risk: if any `brkitr` bundle turns out to resolve through the root locales tree or its pool bundle, the build or break iteration could regress.
3. Uno's text runtime tests pass against the rebuilt package, particularly line/word breaking for CJK and Thai, and bidi for Arabic and Hebrew.

Opened as a draft for that reason.

## Checklist

- [x] Contains **NO** breaking changes
